### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tvuotila/postgresql-notification-listener/security/code-scanning/10](https://github.com/tvuotila/postgresql-notification-listener/security/code-scanning/10)

Add a top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden.  
Best single fix (without changing functionality): set workflow-level permissions to:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only CI operations shown here. No imports, methods, or dependencies are needed; this is purely YAML configuration. Insert the block after the `on:` trigger section and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
