### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/tvuotila/postgresql-notification-listener/security/code-scanning/8](https://github.com/tvuotila/postgresql-notification-listener/security/code-scanning/8)

Add an explicit `permissions` block to the `build` job in `.github/workflows/publish.yml` so the job does not inherit potentially broad defaults.

Best single fix without changing behavior: in job `build` (around lines 9–12), add:

- `permissions:`
- `contents: read`

This is sufficient for `actions/checkout` and does not alter the functional workflow behavior. No imports, methods, or external definitions are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
